### PR TITLE
[Tested] Avoid calling GetAdjustedTime() from static intialization

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -87,14 +87,16 @@ public:
         nProofOfStakeLimit = ~uint256(0) >> 24;
 
         const char* pszTimestamp = "Reuters: Sony Entertainment CEO exiting for a top role at Snap";
-        CTransaction txNew;
-        txNew.vin.resize(1);
-        txNew.vout.resize(1);
-		txNew.vin[0].scriptSig = CScript() << 0 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
-		txNew.vout[0].nValue = (1 * COIN);
-		txNew.vout[0].scriptPubKey = CScript() << ParseHex("04964ae39ac7421145f93a031791749772f671fa1153e4d6df87b1dce87ed2d68a74b46df6cd023ceffbbae4feed084915372d2b8ca866d24dd979af6f09800b3d") << OP_CHECKSIG;
-        txNew.nTime = 1484310000;
-        genesis.vtx.push_back(txNew);
+	std::vector<CTxIn> vin;
+        vin.resize(1);
+        txNew.vin[0].scriptSig = CScript() << 0 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+        std::vector<CTxOut> vout;
+        vout.resize(1);
+	vout[0].scriptPubKey = CScript() << ParseHex("04964ae39ac7421145f93a031791749772f671fa1153e4d6df87b1dce87ed2d68a74b46df6cd023ceffbbae4feed084915372d2b8ca866d24dd979af6f09800b3d") << OP_CHECKSIG;
+        vout[0].nValue = (1 * COIN);
+	CTransaction txNew(1, 1484310000, vin, vout, 0);
+	
+	genesis.vtx.push_back(txNew);
         genesis.hashPrevBlock = 0;
         genesis.hashMerkleRoot = genesis.BuildMerkleTree();
         genesis.nVersion = 1;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -89,7 +89,7 @@ public:
         const char* pszTimestamp = "Reuters: Sony Entertainment CEO exiting for a top role at Snap";
 	std::vector<CTxIn> vin;
         vin.resize(1);
-        txNew.vin[0].scriptSig = CScript() << 0 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+        vin[0].scriptSig = CScript() << 0 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
         std::vector<CTxOut> vout;
         vout.resize(1);
 	vout[0].scriptPubKey = CScript() << ParseHex("04964ae39ac7421145f93a031791749772f671fa1153e4d6df87b1dce87ed2d68a74b46df6cd023ceffbbae4feed084915372d2b8ca866d24dd979af6f09800b3d") << OP_CHECKSIG;


### PR DESCRIPTION
Based off of: https://github.com/rat4/blackcoin/commit/7d766db4014403c4d1562da13247262a5c76e03a